### PR TITLE
Fixed getSpecificPortMappingEntry() null protocol.

### DIFF
--- a/src/main/java/org/bitlet/weupnp/GatewayDevice.java
+++ b/src/main/java/org/bitlet/weupnp/GatewayDevice.java
@@ -349,7 +349,7 @@ public class GatewayDevice {
                 !nameValue.containsKey("NewInternalPort"))
             return false;
 
-        portMappingEntry.setProtocol(nameValue.get("NewProtocol"));
+        portMappingEntry.setProtocol(protocol);
         portMappingEntry.setEnabled(nameValue.get("NewEnabled"));
         portMappingEntry.setInternalClient(nameValue.get("NewInternalClient"));
         portMappingEntry.setExternalPort(externalPort);


### PR DESCRIPTION
The UPnP specification for the "GetSpecificPortMappingEntry" command does not return the "NewProtocol" key. So the protocol will always be set to null. Instead, we set the protocol using the parameter (in a similar manner to externalPort).
