### PR TITLE
(Fix) Break out of loop after device is discovered

### DIFF
--- a/src/main/java/org/bitlet/weupnp/GatewayDiscover.java
+++ b/src/main/java/org/bitlet/weupnp/GatewayDiscover.java
@@ -137,6 +137,7 @@ public class GatewayDiscover {
                         if (Arrays.asList(searchTypes).contains(gatewayDevice.getSt())) {
                             synchronized (devices) {
                                 devices.put(ip, gatewayDevice);
+                                break; // device added for this ip, nothing further to do
                             }
                         }
                     } catch (SocketTimeoutException ste) {


### PR DESCRIPTION
Prior to this fix, after a gateway device was discovered, the loop would continue and you would have to wait for the SocketTimeoutException (3 seconds) before the thread would finish. This speeds up discovery by breaking out of the loop after the device is added.
