### PR TITLE
Make timeouts configurable

### DIFF
--- a/src/main/java/org/bitlet/weupnp/GatewayDevice.java
+++ b/src/main/java/org/bitlet/weupnp/GatewayDevice.java
@@ -51,7 +51,7 @@ public class GatewayDevice {
 	/**
 	 * Receive timeout when requesting data from device
 	 */
-    private static final int HTTP_RECEIVE_TIMEOUT = 7000;
+    private static final int DEFAULT_HTTP_RECEIVE_TIMEOUT = 7000;
     
 	private String st;
     private String location;
@@ -105,6 +105,11 @@ public class GatewayDevice {
     private String modelName;
 
     /**
+     * Timeout in milliseconds for HTTP reads
+     */
+    private static int httpReadTimeout = DEFAULT_HTTP_RECEIVE_TIMEOUT;
+
+    /**
      * Creates a new instance of GatewayDevice
      */
     public GatewayDevice() {
@@ -124,7 +129,7 @@ public class GatewayDevice {
     public void loadDescription() throws SAXException, IOException {
 
         URLConnection urlConn = new URL(getLocation()).openConnection();
-        urlConn.setReadTimeout(HTTP_RECEIVE_TIMEOUT);
+        urlConn.setReadTimeout(httpReadTimeout);
 
         XMLReader parser = XMLReaderFactory.createXMLReader();
         parser.setContentHandler(new GatewayDeviceHandler(this));
@@ -198,7 +203,8 @@ public class GatewayDevice {
         HttpURLConnection conn = (HttpURLConnection) postUrl.openConnection();
 
         conn.setRequestMethod("POST");
-        conn.setReadTimeout(HTTP_RECEIVE_TIMEOUT);
+        conn.setConnectTimeout(httpReadTimeout);
+        conn.setReadTimeout(httpReadTimeout);
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "text/xml");
         conn.setRequestProperty("SOAPAction", soapAction);
@@ -632,6 +638,22 @@ public class GatewayDevice {
 
     public void setModelNumber(String modelNumber) {
         this.modelNumber = modelNumber;
+    }
+
+    /**
+     * Gets the timeout for actions on the device.
+     * @return timeout in milliseconds
+     */
+    public static int getHttpReadTimeout() {
+        return httpReadTimeout;
+    }
+
+    /**
+     * Sets the timeout for actions on the device.
+     * @param milliseconds the new timeout in milliseconds
+     */
+    public static void setHttpReadTimeout(int milliseconds) {
+        httpReadTimeout = milliseconds;
     }
 
     // private methods

--- a/src/main/java/org/bitlet/weupnp/GatewayDiscover.java
+++ b/src/main/java/org/bitlet/weupnp/GatewayDiscover.java
@@ -63,9 +63,14 @@ public class GatewayDiscover {
     public static final String IP = "239.255.255.250";
 
     /**
-     * The timeout to set for the initial broadcast request
+     * The default timeout for the initial broadcast request
      */
-    private static final int TIMEOUT = 3000;
+    private static final int DEFAULT_TIMEOUT = 3000;
+
+    /**
+     * The timeout for the initial broadcast request
+     */
+    private int timeout = DEFAULT_TIMEOUT;
 
     /**
      * The gateway types the discover have to search.
@@ -117,7 +122,7 @@ public class GatewayDiscover {
                 ssdpDiscoverPacket.setPort(PORT);
 
                 ssdp.send(ssdpDiscoverPacket);
-                ssdp.setSoTimeout(TIMEOUT);
+                ssdp.setSoTimeout(GatewayDiscover.this.timeout);
 
                 boolean waitingPacket = true;
                 while (waitingPacket) {
@@ -181,6 +186,22 @@ public class GatewayDiscover {
      */
     public GatewayDiscover(String[] types) {
         this.searchTypes = types;
+    }
+
+    /**
+     * Gets the timeout for socket connections of the initial broadcast request.
+     * @return timeout in milliseconds
+     */
+    public int getTimeout() {
+        return this.timeout;
+    }
+
+    /**
+     * Sets the timeout for socket connections of the initial broadcast request.
+     * @param milliseconds the new timeout in milliseconds
+     */
+    public void setTimeout(int milliseconds) {
+        this.timeout = milliseconds;
     }
 
     /**


### PR DESCRIPTION
In Jitsi we're currently using a forked version of weupnp 1.2. I'm trying to unfork our version, but we need some timeouts to be considerably shorter than currently defined. This PR makes them configurable. The current default is kept as-is.