### PR TITLE
Make weupnp an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bitlet</groupId>
     <artifactId>weupnp</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <version>0.1.4-SNAPSHOT</version>
     <name>weupnp</name>
     <url>https://github.com/bitletorg/weupnp</url>
@@ -45,6 +45,13 @@
                     </archive>
                 </configuration>
                 <version>2.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.4</version>
+                <extensions>true</extensions>
+                <configuration />
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Again for Jitsi: we're running weupnp in an OSGi environment and are currently manually creating the required manifest entries. This PR adds the required entries automatically during the Maven build.