### PR TITLE
Fix for case of weird devices sending weird things

### DIFF
--- a/src/main/java/org/bitlet/weupnp/GatewayDiscover.java
+++ b/src/main/java/org/bitlet/weupnp/GatewayDiscover.java
@@ -147,6 +147,9 @@ public class GatewayDiscover {
                         }
                     } catch (SocketTimeoutException ste) {
                         waitingPacket = false;
+                    } catch (Exception e) {
+                        // Handles the case of weird devices that respond to the query but then do not give a
+                        // valid xml url
                     }
                 }
 


### PR DESCRIPTION
Situation:

Local network has pfSense router with upnp enabled, also has Ubiquity Cloudkey 2.0 that feels like putting its oar in.

A reply comes in to the discovery from the cloud key:
```
HTTP/1.1 200 OK
Cache-Control: max-age = 60
Ext:
Location: http://10.3.0.75:8080/upnp
SERVER: UPnP/1.0 UniFi/6.5.55
ST: upnp:rootdevice
USN: uuid:3C86D905-39E4-4FDC-963C-04E19F2791BB::upnp:rootdevice

```
This results in:
`java.io.FileNotFoundException: http://10.3.0.75:8080/upnp`
(Apparently the URL they provide results in a 404)

After this, the proper router reply comes in.  This change is to basically ignore any device where we get errors trying to parse or understand them.
